### PR TITLE
feat: add ipv4first config parameter

### DIFF
--- a/eufy-security-ws/DOCS.md
+++ b/eufy-security-ws/DOCS.md
@@ -12,7 +12,7 @@
 | `stations`            | Suggested IP addresses or broadcast addresses for stations (optional)                               |
 | `trusted_device_name` | Label of the trusted devices (viewable with 2fa activated in Eufy App; default: random device name) |
 | `debug`               | Activates debug mode (default: false)                                                               |
-| `force_ipv4`          | Forces the use of IPv4 when resolving endpoint addresses (default: false)                           |
+| `ipv4first`           | Forces the dns result order on Node.js to return IPv4 addresses first (default: false)              |
 
 ## Parameter `stations`
 
@@ -36,9 +36,9 @@ stations:
     ip_address: 192.168.0.255 # broadcast address
 ```
 
-## Parameter `force_ipv4`
+## Parameter `ipv4first`
 
-Starting with v17, Node.js no longer orders IPv4 addresses before IPv6 addresses when resolving domain names. The endpoint used for push notifications (`firebaseinstallations.googleapis.com`) unfortunately resolves to a number of different IPv6 addresses that are not reachable from some connections.
+Starting with v17, [Node.js no longer orders IPv4 addresses before IPv6 addresses](https://nodejs.org/api/cli.html#--dns-result-orderorder) when resolving domain names. The endpoint used for push notifications (`firebaseinstallations.googleapis.com`) unfortunately resolves to a number of different IPv6 addresses that are not reachable from some connections.
 
 If you stop receiving push notifications (and are seeing `create push credentials error` messages in the log that repeat endlessly), try setting this to `true`.
 
@@ -52,7 +52,7 @@ port: 3000
 polling_interval: 10
 accept_invitations: true
 debug: false
-force_ipv4: false
+ipv4first: false
 event_duration: 10
 stations:
   - serial_number: T8010XXXXXXXXXXX

--- a/eufy-security-ws/DOCS.md
+++ b/eufy-security-ws/DOCS.md
@@ -12,6 +12,7 @@
 | `stations`            | Suggested IP addresses or broadcast addresses for stations (optional)                               |
 | `trusted_device_name` | Label of the trusted devices (viewable with 2fa activated in Eufy App; default: random device name) |
 | `debug`               | Activates debug mode (default: false)                                                               |
+| `force_ipv4`          | Forces the use of IPv4 when resolving endpoint addresses (default: false)                           |
 
 ## Parameter `stations`
 
@@ -35,6 +36,12 @@ stations:
     ip_address: 192.168.0.255 # broadcast address
 ```
 
+## Parameter `force_ipv4`
+
+Starting with v17, Node.js no longer orders IPv4 addresses before IPv6 addresses when resolving domain names. The endpoint used for push notifications (`firebaseinstallations.googleapis.com`) unfortunately resolves to a number of different IPv6 addresses that are not reachable from some connections.
+
+If you stop receiving push notifications (and are seeing `create push credentials error` messages in the log that repeat endlessly), try setting this to `true`.
+
 ## Example configuration in YAML
 
 ```yaml
@@ -45,6 +52,7 @@ port: 3000
 polling_interval: 10
 accept_invitations: true
 debug: false
+force_ipv4: false
 event_duration: 10
 stations:
   - serial_number: T8010XXXXXXXXXXX

--- a/eufy-security-ws/config.yaml
+++ b/eufy-security-ws/config.yaml
@@ -25,6 +25,7 @@ options:
   polling_interval: 10
   accept_invitations: true
   debug: false
+  force_ipv4: false
   event_duration: 10
   stations: []
 schema:
@@ -35,6 +36,7 @@ schema:
   polling_interval: int(1,1440)
   accept_invitations: bool
   debug: bool
+  force_ipv4: bool
   event_duration: int(1,3600)?
   trusted_device_name: str?
   stations:

--- a/eufy-security-ws/config.yaml
+++ b/eufy-security-ws/config.yaml
@@ -25,7 +25,7 @@ options:
   polling_interval: 10
   accept_invitations: true
   debug: false
-  force_ipv4: false
+  ipv4first: false
   event_duration: 10
   stations: []
 schema:
@@ -36,7 +36,7 @@ schema:
   polling_interval: int(1,1440)
   accept_invitations: bool
   debug: bool
-  force_ipv4: bool
+  ipv4first: bool
   event_duration: int(1,3600)?
   trusted_device_name: str?
   stations:

--- a/eufy-security-ws/run.sh
+++ b/eufy-security-ws/run.sh
@@ -66,6 +66,11 @@ if bashio::config.true 'debug'; then
     DEBUG_OPTION="-v"
 fi
 
+FORCE_IPV4_NODE_OPTION=""
+if bashio::config.true 'force_ipv4'; then
+    FORCE_IPV4_NODE_OPTION="--dns-result-order=ipv4first"
+fi
+
 JSON_STRING="$( jq -n \
   --arg username "$USERNAME" \
   --arg password "$PASSWORD" \
@@ -90,7 +95,7 @@ JSON_STRING="$( jq -n \
 
 if bashio::config.has_value 'username' && bashio::config.has_value 'password'; then
     echo "$JSON_STRING" > $CONFIG_PATH
-    exec /usr/bin/node /usr/src/app/node_modules/eufy-security-ws/dist/bin/server.js --host 0.0.0.0 --config $CONFIG_PATH $DEBUG_OPTION $PORT_OPTION
+    exec /usr/bin/node $FORCE_IPV4_NODE_OPTION /usr/src/app/node_modules/eufy-security-ws/dist/bin/server.js --host 0.0.0.0 --config $CONFIG_PATH $DEBUG_OPTION $PORT_OPTION
 else
     echo "Required parameters username and/or password not set. Starting aborted!"
 fi

--- a/eufy-security-ws/run.sh
+++ b/eufy-security-ws/run.sh
@@ -66,9 +66,9 @@ if bashio::config.true 'debug'; then
     DEBUG_OPTION="-v"
 fi
 
-FORCE_IPV4_NODE_OPTION=""
-if bashio::config.true 'force_ipv4'; then
-    FORCE_IPV4_NODE_OPTION="--dns-result-order=ipv4first"
+IPV4_FIRST_NODE_OPTION=""
+if bashio::config.true 'ipv4first'; then
+    IPV4_FIRST_NODE_OPTION="--dns-result-order=ipv4first"
 fi
 
 JSON_STRING="$( jq -n \
@@ -95,7 +95,7 @@ JSON_STRING="$( jq -n \
 
 if bashio::config.has_value 'username' && bashio::config.has_value 'password'; then
     echo "$JSON_STRING" > $CONFIG_PATH
-    exec /usr/bin/node $FORCE_IPV4_NODE_OPTION /usr/src/app/node_modules/eufy-security-ws/dist/bin/server.js --host 0.0.0.0 --config $CONFIG_PATH $DEBUG_OPTION $PORT_OPTION
+    exec /usr/bin/node $IPV4_FIRST_NODE_OPTION /usr/src/app/node_modules/eufy-security-ws/dist/bin/server.js --host 0.0.0.0 --config $CONFIG_PATH $DEBUG_OPTION $PORT_OPTION
 else
     echo "Required parameters username and/or password not set. Starting aborted!"
 fi

--- a/eufy-security-ws/translations/de.yaml
+++ b/eufy-security-ws/translations/de.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Stationen
     description: Vorgeschlagene IP-Adressen oder Broadcast-Adressen für Stationen
+  ipv4first:
+    name: IPv4-Adressen zuerst erzwingen
+    description: Erzwingt die DNS-Ergebnisreihenfolge auf Node.js, um IPv4-Adressen zuerst zurückzugeben

--- a/eufy-security-ws/translations/en.yaml
+++ b/eufy-security-ws/translations/en.yaml
@@ -26,6 +26,6 @@ configuration:
   stations:
     name: Stations
     description: Suggested IP addresses or broadcast addresses for stations
-  force_ipv4:
-    name: Force IPv4 Connections
-    description: If true, force Node.js to prefer IPv4 to work around push notification connection issues
+  ipv4first:
+    name: Force IPv4 addresses first
+    description: Forces the dns result order on Node.js to return IPv4 addresses first

--- a/eufy-security-ws/translations/en.yaml
+++ b/eufy-security-ws/translations/en.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Stations
     description: Suggested IP addresses or broadcast addresses for stations
+  force_ipv4:
+    name: Force IPv4 Connections
+    description: If true, force Node.js to prefer IPv4 to work around push notification connection issues

--- a/eufy-security-ws/translations/es.yaml
+++ b/eufy-security-ws/translations/es.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Estaciones
     description: Direcciones IP o direcciones de difusión sugeridas para las estaciones
+  ipv4first:
+    name: Forzar direcciones IPv4 primero
+    description: Fuerza el orden de los resultados dns en Node.js para devolver primero las direcciones IPv4

--- a/eufy-security-ws/translations/fr.yaml
+++ b/eufy-security-ws/translations/fr.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Les stations
     description: Adresses IP ou adresses de diffusion suggérées pour les stations
+  ipv4first:
+    name: Forcer les adresses IPv4 en premier
+    description: Force l'ordre des résultats dns sur Node.js à retourner d'abord les adresses IPv4

--- a/eufy-security-ws/translations/it.yaml
+++ b/eufy-security-ws/translations/it.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Stazioni
     description: Indirizzi IP o indirizzi di broadcast suggeriti per le stazioni
+  ipv4first:
+    name: Forza prima indirizzi IPv4
+    description: Forza l'ordine dei risultati dns su Node.js per restituire prima gli indirizzi IPv4

--- a/eufy-security-ws/translations/nl.yaml
+++ b/eufy-security-ws/translations/nl.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Stations
     description: Voorgestelde IP-adressen of broadcast-adressen voor stations
+  ipv4first:
+    name: Tving IPv4-adresser først
+    description: Tvinger DNS-resultatrækkefølgen på Node.js til at returnere IPv4-adresser først

--- a/eufy-security-ws/translations/pl.yaml
+++ b/eufy-security-ws/translations/pl.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Stacje
     description: Sugerowane adresy IP lub adresy rozgłoszeniowe dla stacji
+  ipv4first:
+    name: Wymuś najpierw adresy IPv4
+    description: Wymusza kolejność wyników dns w Node.js, aby najpierw zwracane były adresy IPv4

--- a/eufy-security-ws/translations/pt-BR.yaml
+++ b/eufy-security-ws/translations/pt-BR.yaml
@@ -26,3 +26,6 @@ configuration:
   stations:
     name: Estações
     description: Endereços IP sugeridos ou endereços de transmissão para estações
+  ipv4first:
+    name: Forçar endereços IPv4 primeiro
+    description: Força a ordem dos resultados de dns no Node.js para retornar endereços IPv4 primeiro


### PR DESCRIPTION
Starting in Node.js v17, the DNS resolver no longer forces IPv4 addresses to be at the top of the resolution result, which allows the resolver to dictate the order and lets IPv6 addresses become viable candidates to connect to.

`eufy-security-client` connects to `firebaseinstallations.googleapis.com` to set up push notifications, and this domain has AAAA records. Unfortunately, starting a few days ago on at least some connections (mine included, on Google Fiber ironically), none of the returned IPv6 addresses are actually reachable. This causes push notification registration and token renewal to fail in an endless loop.

This PR adds a new bool param that, if true, tells Node.js to use its legacy behavior and prefer using IPv4 addresses.

Obviously Google should fix the actual problem here and either remove those records or fix the routes, but this parameter addition provides a reasonable workaround until such time that they get around to fixing it.